### PR TITLE
Add copy button to chat messages

### DIFF
--- a/src/views/views.ts
+++ b/src/views/views.ts
@@ -255,6 +255,24 @@ export class ChatbotView extends ItemView {
             cls: `chat-message chat-message-${message.sender}` 
         });
 
+        const copyButton = messageEl.createEl("button", {
+            cls: "chat-message-copy-button",
+            attr: { "aria-label": "Copy message" }
+        });
+        setIcon(copyButton, "copy");
+
+        copyButton.addEventListener("click", () => {
+            navigator.clipboard.writeText(message.content).then(() => {
+                new Notice("Copied to clipboard");
+                setIcon(copyButton, "check");
+                setTimeout(() => {
+                    setIcon(copyButton, "copy");
+                }, 2000);
+            }).catch(() => {
+                new Notice("Failed to copy to clipboard");
+            });
+        });
+
         const contentEl = messageEl.createDiv({ cls: "chat-message-content" });
 
         // Use MarkdownRenderer for bot messages to make [[WikiLinks]] clickable

--- a/src/views/views.ts
+++ b/src/views/views.ts
@@ -273,7 +273,9 @@ export class ChatbotView extends ItemView {
             });
         });
 
-        const contentEl = messageEl.createDiv({ cls: "chat-message-content" });
+        const messageBubble = messageEl.createDiv({ cls: "chat-message-bubble" });
+
+        const contentEl = messageBubble.createDiv({ cls: "chat-message-content" });
 
         // Use MarkdownRenderer for bot messages to make [[WikiLinks]] clickable
         if (message.sender === "bot") {
@@ -294,7 +296,7 @@ export class ChatbotView extends ItemView {
             hour: "2-digit", 
             minute: "2-digit" 
         });
-        messageEl.createDiv({ 
+        messageBubble.createDiv({
             cls: "chat-message-time",
             text: timeStr 
         });

--- a/styles.css
+++ b/styles.css
@@ -104,16 +104,24 @@ If your plugin does not need CSS, delete this file.
 /* Chat Message Styles */
 .chat-message {
     margin-bottom: 12px;
-    padding: 8px 12px;
-    border-radius: 8px;
     max-width: 85%;
     width: fit-content;
-    display: inline-block;
-    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+}
+
+.chat-message-bubble {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 12px;
+    border-radius: 8px;
+    min-width: 0;
 }
 
 .chat-message-copy-button {
-    position: absolute;
+    position: sticky;
+    top: 4px;
     opacity: 0;
     transition: opacity 0.2s;
     background: transparent;
@@ -126,7 +134,7 @@ If your plugin does not need CSS, delete this file.
     display: flex;
     align-items: center;
     justify-content: center;
-    top: 0;
+    flex-shrink: 0;
 }
 
 .chat-message:hover .chat-message-copy-button {
@@ -141,27 +149,36 @@ If your plugin does not need CSS, delete this file.
 
 /* Positioning for bot messages */
 .chat-message-bot .chat-message-copy-button {
-    left: 100%;
-    margin-left: 6px;
+    order: 2;
+}
+.chat-message-bot .chat-message-bubble {
+    order: 1;
 }
 
 /* Positioning for user messages */
 .chat-message-user .chat-message-copy-button {
-    right: 100%;
-    margin-right: 6px;
+    order: 1;
+}
+.chat-message-user .chat-message-bubble {
+    order: 2;
 }
 
 .chat-message-user {
+    margin-left: auto;
+}
+
+.chat-message-user .chat-message-bubble {
     background-color: var(--interactive-accent);
     color: var(--text-on-accent);
-    margin-left: auto;
-    display: block;
 }
 
 .chat-message-bot {
+    margin-right: auto;
+}
+
+.chat-message-bot .chat-message-bubble {
     background-color: var(--background-secondary);
     color: var(--text-normal);
-    margin-right: auto;
 }
 
 .chat-message-content {

--- a/styles.css
+++ b/styles.css
@@ -109,6 +109,46 @@ If your plugin does not need CSS, delete this file.
     max-width: 85%;
     width: fit-content;
     display: inline-block;
+    position: relative;
+}
+
+.chat-message-copy-button {
+    position: absolute;
+    opacity: 0;
+    transition: opacity 0.2s;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 4px;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: 0;
+}
+
+.chat-message:hover .chat-message-copy-button {
+    opacity: 1;
+}
+
+.chat-message-copy-button:hover {
+    color: var(--text-normal);
+    background-color: var(--background-modifier-hover);
+    border-radius: 4px;
+}
+
+/* Positioning for bot messages */
+.chat-message-bot .chat-message-copy-button {
+    left: 100%;
+    margin-left: 6px;
+}
+
+/* Positioning for user messages */
+.chat-message-user .chat-message-copy-button {
+    right: 100%;
+    margin-right: 6px;
 }
 
 .chat-message-user {

--- a/styles.css
+++ b/styles.css
@@ -124,7 +124,8 @@ If your plugin does not need CSS, delete this file.
     top: 4px;
     opacity: 0;
     transition: opacity 0.2s;
-    background: transparent;
+    background-color: transparent;
+    box-shadow: none;
     border: none;
     color: var(--text-muted);
     cursor: pointer;


### PR DESCRIPTION
Added a discrete copy button to chat messages that appears on hover. The button is positioned absolutely next to the message bubble to ensure no layout shifts occur. Implemented using `navigator.clipboard.writeText` with visual feedback (icon change and notification).

---
*PR created automatically by Jules for task [11564401258756360649](https://jules.google.com/task/11564401258756360649) started by @devin201o*